### PR TITLE
feat: runtime zone updates

### DIFF
--- a/server.go
+++ b/server.go
@@ -399,6 +399,10 @@ func (s *Server) PatchNet(r *net.Resolver) {
 	}
 }
 
+func (s *Server) AddZone(name string, zone Zone) error {
+	return s.r.AddZone(name, zone)
+}
+
 func UnpatchNet(r *net.Resolver) {
 	r.PreferGo = false
 	r.Dial = nil

--- a/server.go
+++ b/server.go
@@ -169,7 +169,7 @@ func (s *Server) ServeDNS(w dns.ResponseWriter, m *dns.Msg) {
 		return
 	}
 
-	qnameZone, ok := s.r.Zones[qname]
+	qnameZone, ok := s.r.GetZone(qname)
 	if !ok {
 		s.writeErr(w, reply, notFound(qname))
 		return
@@ -314,7 +314,7 @@ func (s *Server) ServeDNS(w dns.ResponseWriter, m *dns.Msg) {
 			})
 		}
 	case dns.TypePTR:
-		rzone, ok := s.r.Zones[q.Name]
+		rzone, ok := s.r.GetZone(q.Name)
 		if !ok {
 			s.writeErr(w, reply, notFound(q.Name))
 			return
@@ -350,7 +350,7 @@ func (s *Server) ServeDNS(w dns.ResponseWriter, m *dns.Msg) {
 			},
 		}
 	default:
-		rzone, ok := s.r.Zones[q.Name]
+		rzone, ok := s.r.GetZone(q.Name)
 		if !ok {
 			s.writeErr(w, reply, notFound(q.Name))
 			return

--- a/server_test.go
+++ b/server_test.go
@@ -158,7 +158,7 @@ func TestServer_Authoritative(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	srv.Resolver().SkipCNAME = true
+	srv.Resolver().SetSkipCNAME(true)
 	defer srv.Close()
 
 	msg := new(dns.Msg)

--- a/server_test.go
+++ b/server_test.go
@@ -2,6 +2,7 @@ package mockdns
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"reflect"
 	"sort"
@@ -173,5 +174,160 @@ func TestServer_Authoritative(t *testing.T) {
 	}
 	if !reply.MsgHdr.Authoritative {
 		t.Fatal("The authoritative flag should be set")
+	}
+}
+
+func TestServer_AddZone_Simple(t *testing.T) {
+	const (
+		initialZoneName    = "initial.example"
+		additionalZoneName = "additional.example"
+		expectedName       = "resolved.example"
+	)
+
+	// create server with initial zone record
+	srv, err := NewServer(map[string]Zone{
+		initialZoneName: Zone{
+			CNAME: expectedName,
+		},
+	}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Close()
+
+	// ensure initial zone record resolves correctly
+	resolvedInitialName, err := srv.Resolver().LookupCNAME(context.Background(), initialZoneName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if expectedName != resolvedInitialName {
+		t.Fatalf("expected: %s; got: %s", expectedName, resolvedInitialName)
+	}
+
+	// add additional zone record
+	err = srv.AddZone(additionalZoneName, Zone{
+		CNAME: expectedName,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// ensure additional zone record resolves correctly
+	resolvedAdditionalName, err := srv.Resolver().LookupCNAME(context.Background(), additionalZoneName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if expectedName != resolvedAdditionalName {
+		t.Fatalf("expected: %s; got: %s", expectedName, resolvedInitialName)
+	}
+}
+
+func TestServer_AddZone_Existing(t *testing.T) {
+	const (
+		initialZoneName = "initial.example"
+		expectedName    = "expected.example"
+		unexpectedName  = "unexpected.example"
+	)
+
+	var expectedErr = fmt.Errorf(ErrExistingZoneFmt, initialZoneName)
+
+	// create server with initial zone record
+	srv, err := NewServer(map[string]Zone{
+		initialZoneName: Zone{
+			CNAME: expectedName,
+		},
+	}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Close()
+
+	// ensure initial zone record resolves correctly
+	resolvedInitialName, err := srv.Resolver().LookupCNAME(context.Background(), initialZoneName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if expectedName != resolvedInitialName {
+		t.Fatalf("expected: %q but got: %q", initialZoneName, resolvedInitialName)
+	}
+
+	// attempt to add existing zone record
+	err = srv.AddZone(initialZoneName, Zone{
+		CNAME: unexpectedName,
+	})
+	if expectedErr.Error() != err.Error() {
+		t.Fatalf("expected error %q but got %q", expectedErr, err)
+	}
+
+	// ensure initial zone record resolves correctly
+	resolvedInitialName, err = srv.Resolver().LookupCNAME(context.Background(), initialZoneName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if expectedName != resolvedInitialName {
+		t.Fatalf("expected: %q but got: %q", initialZoneName, resolvedInitialName)
+	}
+
+	// ensure unexpected zone record does not resolve
+	_, err = srv.Resolver().LookupCNAME(context.Background(), unexpectedName)
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+}
+
+func TestServer_AddZone_Concurrent(t *testing.T) {
+	const (
+		initialZoneName    = "initial.example"
+		additionalZoneName = "additional.example"
+		expectedName       = "resolved.example"
+	)
+
+	var (
+		errCh = make(chan error, 1)
+	)
+
+	// create server with initial zone record
+	srv, err := NewServer(map[string]Zone{
+		initialZoneName: Zone{
+			CNAME: expectedName,
+		},
+	}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Close()
+
+	go func() {
+		// add additional zone record
+		err := srv.AddZone(additionalZoneName, Zone{
+			CNAME: expectedName,
+		})
+		if err != nil {
+			errCh <- err
+		}
+
+		// ensure additional zone record resolves correctly
+		resolvedAdditionalName, err := srv.Resolver().LookupCNAME(context.Background(), additionalZoneName)
+		if err != nil {
+			errCh <- err
+		}
+		if expectedName != resolvedAdditionalName {
+			errCh <- fmt.Errorf("expected: %s but got: %s", expectedName, resolvedAdditionalName)
+		}
+
+		close(errCh)
+	}()
+
+	// ensure initial zone record resolves correctly
+	resolvedInitialName, err := srv.Resolver().LookupCNAME(context.Background(), initialZoneName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if expectedName != resolvedInitialName {
+		t.Fatalf("expected: %s; got: %s", expectedName, resolvedInitialName)
+	}
+
+	if err := <-errCh; err != nil {
+		t.Fatalf("unexpected error: %s", err)
 	}
 }


### PR DESCRIPTION
### Summary

This pull request adds support for runtime zone updates by introducing `AddZone()` methods to both the `Server` and `Resolver` structs. This allows for adding new zones without requiring a server restart.

### Changes

- Introduce a new `sync.RWMutex` to `Resolver` for safe concurrent access to its `Zones` field.
- Update existing methods in `Resolver` to use the newly introduced mutex for safely reading and modifying the `Zones` field.
- Add new `AddZone()` methods to both the `Server` and `Resolver` structs for adding new zones.
- Update `Server` to use the new `Resolver.GetZone()` method instead of directly accessing `Resolver.Zones`.
- Add a new test `TestServer_AddZone()` in `server_test.go` to verify the correct behavior of the `AddZone()` method.